### PR TITLE
Log JSON with timestamp

### DIFF
--- a/coupons.cabal
+++ b/coupons.cabal
@@ -69,6 +69,7 @@ executable coupons
   build-depends:
       base >=4.7 && <5
     , coupons
+    , fast-logger
     , fused-effects
     , postgresql-simple
     , resource-pool

--- a/coupons.cabal
+++ b/coupons.cabal
@@ -107,5 +107,6 @@ test-suite coupons-test
                 , postgresql-simple-migration
                 , tmp-postgres
                 , bytestring
-                , time
+                , chronos
+                , torsor
   default-language: Haskell2010

--- a/coupons.cabal
+++ b/coupons.cabal
@@ -54,7 +54,8 @@ library
     , postgresql-simple-migration
     , tmp-postgres
     , bytestring
-    , time
+    , chronos
+    , torsor
     , random
   default-language: Haskell2010
 

--- a/src/Domain/Context.hs
+++ b/src/Domain/Context.hs
@@ -14,7 +14,7 @@ import GHC.OverloadedLabels (IsLabel(..))
 import GHC.TypeLits (Symbol)
 import GHC.Generics
 
-import Data.Time.Clock
+import Chronos
 import Data.Aeson
 
 import Domain.Shared
@@ -36,7 +36,7 @@ data Context = Context
   , bundles  :: [Bundle]
   , location :: Maybe String
   , codes    :: [Code]
-  , time     :: UTCTime
+  , time     :: Time
   } deriving (Generic, Show)
 
 instance FromJSON Context where

--- a/src/Domain/Rule.hs
+++ b/src/Domain/Rule.hs
@@ -3,13 +3,13 @@ module Domain.Rule where
 
 import GHC.Generics
 
-import Data.Time.Clock
+import Chronos
 import Data.Aeson
 
 import Domain.Shared
 
-type StartDate = UTCTime
-type EndDate = UTCTime
+type StartDate = Time
+type EndDate = Time
 type MinAmount = Integer
 type Count = Integer
 type Slug = String

--- a/src/Domain/RuleRepositorySpec.hs
+++ b/src/Domain/RuleRepositorySpec.hs
@@ -10,8 +10,6 @@ import GHC.IO
 import Database.PostgreSQL.Simple hiding (In)
 import Database.Postgres.Temp
 
--- import Data.Time.Calendar
--- import Data.Time.Clock
 import Chronos
 
 import Test.Hspec

--- a/src/Domain/RuleRepositorySpec.hs
+++ b/src/Domain/RuleRepositorySpec.hs
@@ -10,8 +10,9 @@ import GHC.IO
 import Database.PostgreSQL.Simple hiding (In)
 import Database.Postgres.Temp
 
-import Data.Time.Calendar
-import Data.Time.Clock
+-- import Data.Time.Calendar
+-- import Data.Time.Clock
+import Chronos
 
 import Test.Hspec
 
@@ -36,7 +37,7 @@ spec = parallel $ do
         ["test", "2"]
 
     it "finds a code in DateRange" $ do
-      let time = UTCTime (fromGregorian 1989 10 18) 0
+      let time = datetimeToTime $ Datetime (Date (Year 1989) (Month 10) (DayOfMonth 18)) (TimeOfDay 0 0 0)
       getCodes (Between time time (Has (Code "test") $ Is ""))
         `shouldBe`
         ["test"]

--- a/src/Effects/Logging.hs
+++ b/src/Effects/Logging.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, KindSignatures, GADTs, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE OverloadedStrings, DuplicateRecordFields, DeriveGeneric, TypeApplications, DeriveFunctor, KindSignatures, GADTs, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Effects.Logging
   ( Log, log, runLogIO, runLogFile )
 where
@@ -12,6 +12,12 @@ import Control.Carrier.Writer.Strict
 import Control.Carrier.Lift
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Kind (Type)
+
+import Control.Applicative
+import Data.Aeson hiding (Error)
+import GHC.Generics hiding ((:+:))
+
+import Chronos
 
 -- Fast logger
 import System.Log.FastLogger
@@ -28,12 +34,12 @@ data Message
   | Warn  String
 
 -- Render a structured log message as a string.
-renderLogMessage :: Message -> String
+renderLogMessage :: Message -> LogMessage
 renderLogMessage message = case message of
-  Error message -> "[error] " ++ message
-  Debug message -> "[debug] " ++ message
-  Info  message -> "[info] "  ++ message
-  Warn  message -> "[warn] "  ++ message
+  Error message -> LogMessage { level="error", message=message }
+  Debug message -> LogMessage { level="debug", message=message }
+  Info  message -> LogMessage { level="info",  message=message }
+  Warn  message -> LogMessage { level="warn",  message=message }
 
 --
 -- The logging effect
@@ -43,7 +49,7 @@ renderLogMessage message = case message of
 -- the effect!
 
 data Log (m :: Type -> Type) k where
-  Write :: String -> Log m ()
+  Write :: LogMessage -> Log m ()
 
 log' :: Has Log sig m => Message -> m ()
 log' message = send (Write $ renderLogMessage message)
@@ -81,36 +87,74 @@ instance (MonadIO m, Algebra sig m) => Algebra (Log :+: sig) (LogIO m) where
     R other       -> LogIO (alg (runLogIO . handle) other context)
 
 
-data LogWrapper = LogWrapper
-
 newtype LogFileCarrier m a = LogFileCarrier (FastLogger -> m a)
   deriving (Functor)
 
-instance Functor m => Applicative (LogFileCarrier m) where
+instance Applicative m => Applicative (LogFileCarrier m) where
+  pure = LogFileCarrier . const . pure
+  LogFileCarrier f <*> LogFileCarrier a = LogFileCarrier (liftA2 (<*>) f a)
 
-instance Functor m => Monad (LogFileCarrier m) where
+instance Monad m => Monad (LogFileCarrier m) where
+  LogFileCarrier a >>= f = LogFileCarrier (\r -> a r >>= runLogFile r . f)
 
 runLogFile :: FastLogger -> LogFileCarrier m a -> m a
 runLogFile logger (LogFileCarrier runLogCarrier) = runLogCarrier logger
 
+data LogMessage = LogMessage
+  { level   :: String
+  , message :: String }
+  deriving (Generic, Show)
+
+instance ToJSON LogMessage where
+
+instance ToLogStr LogMessage where
+  toLogStr msg = toLogStr $ encode msg
+
+data LogMessageWithTimestamp = LogMessageWithTimestamp
+  { level     :: String
+  , message   :: String
+  , timestamp :: Datetime }
+  deriving (Generic, Show)
+
+instance ToJSON LogMessageWithTimestamp where
+
+instance ToLogStr LogMessageWithTimestamp where
+  toLogStr msg = toLogStr $ encode msg
+
+handleLogMessage :: Time -> LogMessage -> LogStr
+handleLogMessage ts logMessage =
+  let
+    LogMessage{ level=level, message=message } = logMessage
+  in
+    toLogStr $ LogMessageWithTimestamp
+      { level=level
+      , message=message
+      , timestamp=timeToDatetime ts
+      }
 
 instance (MonadIO m, Algebra  sig m) => Algebra (Log :+: sig) (LogFileCarrier m) where
   alg handle sig context = LogFileCarrier $ \logger -> case sig of
-    L (Write msg) -> context <$ liftIO (logger $ toLogStr msg)
+    L (Write msg) -> do
+      ts <- liftIO now
+      context <$ liftIO (logger $ handleLogMessage ts msg)
     R other       -> alg (runLogFile logger . handle) other context
 
 
 --
 -- Example usage
 --
-application :: Has Log sig m => m ()
-application = do
-  logInfo "hello"
 
-main :: IO ()
-main = do
-  (logger, cleanup) <- newFastLogger (LogStdout defaultBufSize)
-
-  runM
-    . runLogFile logger
-    $ application
+-- application :: Has Log sig m => m ()
+-- application = do
+--   logInfo "hello"
+--
+-- timeStampFormat :: TimeFormat
+-- timeStampFormat = "%Y-%m-%d %H:%M:%S"
+--
+-- main :: IO ()
+-- main = do
+--   (logger, cleanup) <- newFastLogger (LogStdout defaultBufSize)
+--
+--   runM
+--     . runLogFile logger
+--     $ application

--- a/src/Helpers/Gen.hs
+++ b/src/Helpers/Gen.hs
@@ -4,15 +4,15 @@ module Helpers.Gen where
 import System.Random
 import Database.PostgreSQL.Simple hiding (In)
 import Data.Aeson
-import Data.Time.Clock
-import Data.Time.Calendar
+import Chronos
+import Torsor
 
 import Domain.Rule
 import Domain.Shared
 
-dayDiff = secondsToNominalDiffTime (24 * 60 * 60)
-
-todayUTC = UTCTime (fromGregorian 2021 5 21) 0
+todayUTC = datetimeToTime
+  $ Datetime (Date (Year 2021) (Month 5) (DayOfMonth 21)) (TimeOfDay 0 0 0)
+tomorrowUTC = add day todayUTC
 
 openRules :: [Rule]
 openRules =
@@ -24,7 +24,7 @@ openRules =
   , Rule (OneOf [ Has (One "cat") (Is "cat-code")
                 , Has (One "dog") (Is "dog-code")
                 ] $ Is "cat-or-dog-code") [AmountOff 10 WholeCart]
-  , Rule (Between todayUTC (addUTCTime dayDiff todayUTC) $ Is "today only") []
+  , Rule (Between todayUTC tomorrowUTC $ Is "today only") []
   ]
 
 -- insert a bunch of rules

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -19,7 +19,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Control.Algebra (Has)
 import Control.Carrier.Reader
 import Control.Carrier.Lift
-import Effects.Logging (Log, log, runLogIO)
+import Effects.Logging (Log, log, runLogIO, runLogFile)
 
 import Data.List
 import Data.Maybe
@@ -121,7 +121,11 @@ getActions context = do
 
   pure matchedRules
 
-runGetActions :: MonadIO m => Connection -> Context -> m (Either RepoError [(Code, [Action])])
+runGetActions
+  :: MonadIO m
+  => Connection
+  -> Context
+  -> m (Either RepoError [(Code, [Action])])
 runGetActions conn context =
   runM
   . runLogIO

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -19,7 +19,8 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Control.Algebra (Has)
 import Control.Carrier.Reader
 import Control.Carrier.Lift
-import Effects.Logging (Log, log, runLogIO, runLogFile)
+import Effects.Logging (Log, log, logError, runLogger)
+import System.Log.FastLogger
 
 import Data.List
 import Data.Maybe
@@ -119,16 +120,21 @@ getActions context = do
     combined = (<>) <$> openRules <*> closedRules
     matchedRules = mapMaybe (evalRule context) <$> combined
 
+  case matchedRules of
+    Left error  -> logError (show error)
+    Right rules -> log $ "Found rules: " <> show rules <> " for cart: " <> show context
+
   pure matchedRules
 
 runGetActions
   :: MonadIO m
   => Connection
+  -> FastLogger
   -> Context
   -> m (Either RepoError [(Code, [Action])])
-runGetActions conn context =
+runGetActions conn logger context =
   runM
-  . runLogIO
   . runReader conn
   . runRuleRepoIO
+  . runLogger logger
   $ getActions context

--- a/src/ServiceSpec.hs
+++ b/src/ServiceSpec.hs
@@ -150,7 +150,6 @@ spec = parallel $ do
 
     describe "Between" $ do
 
-      -- let day = secondsToNominalDiffTime (24 * 60 * 60)
       currentTime <- runIO now
 
       it "matches if the current time is in range" $ do

--- a/src/ServiceSpec.hs
+++ b/src/ServiceSpec.hs
@@ -5,8 +5,8 @@ import Control.Carrier.Lift
 import Control.Carrier.State.Strict
 import Effects.Logging (runLogIO)
 
-import Data.Time.Clock
-import Data.Time.Calendar
+import Chronos
+import Torsor
 
 import Test.Hspec
 
@@ -24,7 +24,7 @@ spec = parallel $ do
         , bundles = []
         , location = Nothing
         , codes = []
-        , time = UTCTime (fromGregorian 1989 10 18) 0
+        , time = datetimeToTime (Datetime (Date (Year 1989) (Month 10) (DayOfMonth 0)) (TimeOfDay 0 0 0))
         }
 
   describe "findAllSlugs" $ do
@@ -148,15 +148,15 @@ spec = parallel $ do
         `shouldBe`
           Nothing
 
-    describe "Between " $ do
+    describe "Between" $ do
 
-      let day = secondsToNominalDiffTime (24 * 60 * 60)
-      currentTime <- runIO getCurrentTime
+      -- let day = secondsToNominalDiffTime (24 * 60 * 60)
+      currentTime <- runIO now
 
       it "matches if the current time is in range" $ do
         let
-          future = addUTCTime day currentTime
-          past = addUTCTime (negate day) currentTime
+          future = add day currentTime
+          past = add (invert day) currentTime
 
         evalExpression
           context{ time=currentTime }
@@ -166,8 +166,8 @@ spec = parallel $ do
 
       it "finds nothing if not in range" $ do
         let
-          future = addUTCTime day currentTime
-          past = addUTCTime (negate day) currentTime
+          future = add day currentTime
+          past = add (invert day) currentTime
 
         evalExpression
           context -- since we initalized it with 1989 as the year


### PR DESCRIPTION
Now we get nice standard log message like so:

formatted:
```
{
  "message": "Found rules: [] for cart: Context {items = [], bundles = [], location = Nothing, codes = [], time = Time {getTime = 1627743237631585395}}",
  "timestamp": "2021-07-31 15:27:03.849857007",
  "level": "info"
}
```

As part of this I realized `TimedFastLogger` doesn't support resolution of less than a second, owing to the time formatter it uses throwing out microseconds.  Chronos does support that, and as a bonus it's supposedly much faster than the old `Time` library.